### PR TITLE
fix(typings): Correct typings file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "author": "Rob Eisenberg <rob@bluespire.com> (http://robeisenberg.com/)",
   "main": "dist/commonjs/aurelia-middleware-koa.js",
-  "typings": "dist/aurelia-middleware-koa.d.ts",
+  "typings": "dist/commonjs/aurelia-middleware-koa.d.ts",
   "repository": {
     "type": "git",
     "url": "http://github.com/aurelia/middleware-koa"


### PR DESCRIPTION
The package.json file previously referred to the typings file,
aurelia-middleware-koa.d.ts, in the ./dist directory. The typings file
is not in the ./dist directory, it is generated in each of the child
directories for the various module types (e.g. amd, commonjs).

For consistency with other Aurelia projects, this commit changes the
typings field in the package.json file to reference:
./dist/commonjs/aurelia-middleware-koa.d.ts